### PR TITLE
ViewModel の実装 - フォームでエラーバリデーションを行う

### DIFF
--- a/lib/domain/models/common/validation_result.dart
+++ b/lib/domain/models/common/validation_result.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'validation_result.freezed.dart';
+
+/// バリデーションの結果
+@freezed
+sealed class ValidationResult with _$ValidationResult {
+  /// バリデーション成功
+  const factory ValidationResult.success() = ValidationSuccess;
+
+  /// バリデーションエラー
+  const factory ValidationResult.error(String message) = ValidationError;
+}
+
+/// バリデーションの結果拡張
+extension ValidationResultExtension on ValidationResult {
+  /// バリデーション成功かどうか
+  bool get isValid => this is ValidationSuccess;
+
+  /// バリデーションエラーかどうか
+  bool get isError => this is ValidationError;
+}

--- a/lib/domain/models/common/validation_result.freezed.dart
+++ b/lib/domain/models/common/validation_result.freezed.dart
@@ -1,0 +1,324 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'validation_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ValidationResult {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() success,
+    required TResult Function(String message) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? success,
+    TResult? Function(String message)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? success,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ValidationSuccess value) success,
+    required TResult Function(ValidationError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ValidationSuccess value)? success,
+    TResult? Function(ValidationError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ValidationSuccess value)? success,
+    TResult Function(ValidationError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ValidationResultCopyWith<$Res> {
+  factory $ValidationResultCopyWith(
+          ValidationResult value, $Res Function(ValidationResult) then) =
+      _$ValidationResultCopyWithImpl<$Res, ValidationResult>;
+}
+
+/// @nodoc
+class _$ValidationResultCopyWithImpl<$Res, $Val extends ValidationResult>
+    implements $ValidationResultCopyWith<$Res> {
+  _$ValidationResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ValidationResult
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$ValidationSuccessImplCopyWith<$Res> {
+  factory _$$ValidationSuccessImplCopyWith(_$ValidationSuccessImpl value,
+          $Res Function(_$ValidationSuccessImpl) then) =
+      __$$ValidationSuccessImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$ValidationSuccessImplCopyWithImpl<$Res>
+    extends _$ValidationResultCopyWithImpl<$Res, _$ValidationSuccessImpl>
+    implements _$$ValidationSuccessImplCopyWith<$Res> {
+  __$$ValidationSuccessImplCopyWithImpl(_$ValidationSuccessImpl _value,
+      $Res Function(_$ValidationSuccessImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ValidationResult
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$ValidationSuccessImpl implements ValidationSuccess {
+  const _$ValidationSuccessImpl();
+
+  @override
+  String toString() {
+    return 'ValidationResult.success()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$ValidationSuccessImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() success,
+    required TResult Function(String message) error,
+  }) {
+    return success();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? success,
+    TResult? Function(String message)? error,
+  }) {
+    return success?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? success,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ValidationSuccess value) success,
+    required TResult Function(ValidationError value) error,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ValidationSuccess value)? success,
+    TResult? Function(ValidationError value)? error,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ValidationSuccess value)? success,
+    TResult Function(ValidationError value)? error,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ValidationSuccess implements ValidationResult {
+  const factory ValidationSuccess() = _$ValidationSuccessImpl;
+}
+
+/// @nodoc
+abstract class _$$ValidationErrorImplCopyWith<$Res> {
+  factory _$$ValidationErrorImplCopyWith(_$ValidationErrorImpl value,
+          $Res Function(_$ValidationErrorImpl) then) =
+      __$$ValidationErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$ValidationErrorImplCopyWithImpl<$Res>
+    extends _$ValidationResultCopyWithImpl<$Res, _$ValidationErrorImpl>
+    implements _$$ValidationErrorImplCopyWith<$Res> {
+  __$$ValidationErrorImplCopyWithImpl(
+      _$ValidationErrorImpl _value, $Res Function(_$ValidationErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ValidationResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$ValidationErrorImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ValidationErrorImpl implements ValidationError {
+  const _$ValidationErrorImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'ValidationResult.error(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ValidationErrorImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of ValidationResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ValidationErrorImplCopyWith<_$ValidationErrorImpl> get copyWith =>
+      __$$ValidationErrorImplCopyWithImpl<_$ValidationErrorImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() success,
+    required TResult Function(String message) error,
+  }) {
+    return error(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? success,
+    TResult? Function(String message)? error,
+  }) {
+    return error?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? success,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ValidationSuccess value) success,
+    required TResult Function(ValidationError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ValidationSuccess value)? success,
+    TResult? Function(ValidationError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ValidationSuccess value)? success,
+    TResult Function(ValidationError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ValidationError implements ValidationResult {
+  const factory ValidationError(final String message) = _$ValidationErrorImpl;
+
+  String get message;
+
+  /// Create a copy of ValidationResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ValidationErrorImplCopyWith<_$ValidationErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/validators/title_validator.dart
+++ b/lib/domain/validators/title_validator.dart
@@ -1,0 +1,17 @@
+import 'package:todo_app/domain/validators/validator.dart';
+
+import '../models/common/validation_result.dart';
+
+/// タイトルのバリデータ
+class TitleValidator implements Validator {
+  @override
+  ValidationResult validate(String value) {
+    if (value.isEmpty) {
+      return ValidationResult.error('タイトルは必須です');
+    }
+    if (value.length > 50) {
+      return ValidationResult.error('タイトルは50文字以内で入力してください');
+    }
+    return ValidationResult.success();
+  }
+}

--- a/lib/domain/validators/validator.dart
+++ b/lib/domain/validators/validator.dart
@@ -1,0 +1,7 @@
+import '../models/common/validation_result.dart';
+
+/// バリデータの interface
+abstract interface class Validator {
+  /// バリデーションを行う
+  ValidationResult validate(String value);
+}

--- a/lib/ui/components/text_input_widget.dart
+++ b/lib/ui/components/text_input_widget.dart
@@ -1,29 +1,41 @@
 import 'package:flutter/material.dart';
 
+import '../../domain/validators/validator.dart';
+
 /// テキスト入力フォームウィジェット
 class TextInputWidget extends StatelessWidget {
   const TextInputWidget({
     super.key,
     required this.controller,
     required this.hintText,
+    required this.validator,
   });
 
   /// コントローラー
   final TextEditingController controller;
+
   /// ヒントテキスト
   final String hintText;
+
+  /// バリデータ
+  final Validator validator;
 
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      TextField(
+      TextFormField(
         controller: controller,
         decoration: InputDecoration(
-          border: InputBorder.none,
-          isDense: true,
-          contentPadding: EdgeInsets.zero,
-          hintText: hintText,
-        ),
+            border: InputBorder.none, isDense: true, contentPadding: EdgeInsets.zero, hintText: hintText, counterText: ''),
+        autovalidateMode: AutovalidateMode.onUserInteraction,
+        validator: (String? value) {
+          final result = validator.validate(controller.text);
+          return result.when(
+            success: () => null,
+            error: (message) => message,
+          );
+        },
+        maxLength: 100,
       ),
       Divider(),
     ]);

--- a/lib/ui/pages/adding_todo/adding_todo_page.dart
+++ b/lib/ui/pages/adding_todo/adding_todo_page.dart
@@ -16,14 +16,11 @@ class AddingTodoPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(addingTodoViewModelProvider);
-    final controller =
-        useTextEditingController.fromValue(TextEditingValue.empty);
+    final controller = useTextEditingController.fromValue(TextEditingValue.empty);
 
     useEffect(() {
       controller.addListener(() {
-        ref
-            .read(addingTodoViewModelProvider.notifier)
-            .updateTitle(controller.text);
+        ref.read(addingTodoViewModelProvider.notifier).updateTitle(controller.text);
       });
       return null;
     }, const []);
@@ -35,30 +32,27 @@ class AddingTodoPage extends HookConsumerWidget {
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(
-            spacing: 16,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text('タイトル', style: Theme.of(context).textTheme.labelLarge),
-              TextInputWidget(
-                  controller: controller, hintText: 'タイトルを入力してください'),
-              Text('締切日時', style: Theme.of(context).textTheme.labelLarge),
-              DueDateTimeInputWidget(
-                  dueDateTime: state.dueDateTime,
-                  hintText: '締切日時を選択してください',
-                  onDueDateTimeSelected: (DueDateTime value) {
-                    ref
-                        .read(addingTodoViewModelProvider.notifier)
-                        .setDueDateTime(value);
-                  }),
-            ]),
+        child: Column(spacing: 16, crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
+          Text('タイトル', style: Theme.of(context).textTheme.labelLarge),
+          TextInputWidget(
+              controller: controller,
+              hintText: 'タイトルを入力してください',
+              validator: ref.read(addingTodoViewModelProvider.notifier).titleValidator),
+          Text('締切日時', style: Theme.of(context).textTheme.labelLarge),
+          DueDateTimeInputWidget(
+              dueDateTime: state.dueDateTime,
+              hintText: '締切日時を選択してください',
+              onDueDateTimeSelected: (DueDateTime value) {
+                ref.read(addingTodoViewModelProvider.notifier).updateDueDateTime(value);
+              }),
+        ]),
       ),
       floatingActionButton: FloatingActionButton(
-        backgroundColor: state.isValid
+        backgroundColor: ref.read(addingTodoViewModelProvider.notifier).canAddTodo
             ? Theme.of(context).floatingActionButtonTheme.backgroundColor
             : Colors.grey,
         onPressed: () {
-          if (!state.isValid) return;
+          if (!ref.read(addingTodoViewModelProvider.notifier).canAddTodo) return;
           Navigator.pop(
             context,
             state.toTodoItem(),

--- a/lib/ui/pages/adding_todo/adding_todo_view_model.dart
+++ b/lib/ui/pages/adding_todo/adding_todo_view_model.dart
@@ -1,6 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:todo_app/domain/models/common/validation_result.dart';
 import 'package:todo_app/domain/models/types/due_date_time.dart';
+import 'package:todo_app/domain/validators/title_validator.dart';
 
 import '../../../domain/models/todo_item.dart';
 
@@ -15,17 +17,26 @@ class AddingTodoViewModel extends _$AddingTodoViewModel {
     dueDateTime: null,
   );
 
+  final _titleValidator = TitleValidator();
+
   @override
   AddingTodoState build() => _addingTodoState;
 
+  /// タイトルを更新
   void updateTitle(String title) {
     state = state.copyWith(title: title);
   }
 
-  /// 締切期日を設定
-  void setDueDateTime(DueDateTime dueDateTime) {
+  /// タイトルのバリデータ
+  TitleValidator get titleValidator => _titleValidator;
+
+  /// 締切日時を更新
+  void updateDueDateTime(DueDateTime dueDateTime) {
     state = state.copyWith(dueDateTime: dueDateTime);
   }
+
+  /// To-Do 追加可能かどうか
+  bool get canAddTodo => titleValidator.validate(state.title).isValid && state.dueDateTime != null;
 }
 
 /// To-Do 追加画面の状態
@@ -42,14 +53,8 @@ class AddingTodoState with _$AddingTodoState {
 
 /// To-Do 追加画面の状態拡張
 extension AddingTodoStateExtension on AddingTodoState {
-  /// 入力が有効かどうか
-  bool get isValid => title.isNotEmpty && dueDateTime != null;
-
   /// [TodoItem] に変換
   TodoItem toTodoItem() {
-    if (!isValid) {
-      throw Exception('Invalid state');
-    }
     return TodoItem(
       title: title,
       isCompleted: false,

--- a/lib/ui/pages/adding_todo/adding_todo_view_model.g.dart
+++ b/lib/ui/pages/adding_todo/adding_todo_view_model.g.dart
@@ -7,7 +7,7 @@ part of 'adding_todo_view_model.dart';
 // **************************************************************************
 
 String _$addingTodoViewModelHash() =>
-    r'fab9c459fd45e4d38640715fb4b7c1b3e37fd306';
+    r'1f3d8efb01aae79cce8d72e9f4f166c07e71a1ed';
 
 /// To-Do 追加画面の ViewModel
 ///


### PR DESCRIPTION
## 概要
フォームでバリデーションを行うように修正

## 関連 issue
- close #21
- #10

## 関連 PR
- #12 

## 参考
- https://docs.flutter.dev/release/breaking-changes/form-field-autovalidation-api
- https://dart.dev/language/class-modifiers#abstract-interface
- https://pub.dev/packages/freezed#mixins-and-interfaces-for-individual-classes-for-union-types
- https://qiita.com/suga_slj/items/efe3dd6b714b5fa65612
