### PR TITLE
Provider を使って Validator を注入するように修正

### DIFF
--- a/lib/domain/validators/title_validator.dart
+++ b/lib/domain/validators/title_validator.dart
@@ -1,6 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:todo_app/domain/validators/validator.dart';
 
 import '../models/common/validation_result.dart';
+
+part 'title_validator.g.dart';
 
 /// タイトルのバリデータ
 class TitleValidator implements Validator {
@@ -15,3 +19,6 @@ class TitleValidator implements Validator {
     return ValidationResult.success();
   }
 }
+
+@riverpod
+TitleValidator titleValidator(Ref ref) => TitleValidator();

--- a/lib/domain/validators/title_validator.g.dart
+++ b/lib/domain/validators/title_validator.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'title_validator.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$titleValidatorHash() => r'0aceab4555da94a51eb3beacfc30e104c9328989';
+
+/// See also [titleValidator].
+@ProviderFor(titleValidator)
+final titleValidatorProvider = AutoDisposeProvider<TitleValidator>.internal(
+  titleValidator,
+  name: r'titleValidatorProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$titleValidatorHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef TitleValidatorRef = AutoDisposeProviderRef<TitleValidator>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/ui/pages/adding_todo/adding_todo_view_model.dart
+++ b/lib/ui/pages/adding_todo/adding_todo_view_model.dart
@@ -12,15 +12,16 @@ part 'adding_todo_view_model.g.dart';
 /// To-Do 追加画面の ViewModel
 @riverpod
 class AddingTodoViewModel extends _$AddingTodoViewModel {
-  final AddingTodoState _addingTodoState = AddingTodoState(
-    title: "",
-    dueDateTime: null,
-  );
-
-  final _titleValidator = TitleValidator();
+  late final TitleValidator _titleValidator;
 
   @override
-  AddingTodoState build() => _addingTodoState;
+  AddingTodoState build() {
+    _titleValidator = ref.read(titleValidatorProvider);
+    return AddingTodoState(
+      title: "",
+      dueDateTime: null,
+    );
+  }
 
   /// タイトルを更新
   void updateTitle(String title) {

--- a/lib/ui/pages/adding_todo/adding_todo_view_model.g.dart
+++ b/lib/ui/pages/adding_todo/adding_todo_view_model.g.dart
@@ -7,7 +7,7 @@ part of 'adding_todo_view_model.dart';
 // **************************************************************************
 
 String _$addingTodoViewModelHash() =>
-    r'1f3d8efb01aae79cce8d72e9f4f166c07e71a1ed';
+    r'688aa586709cdc4a1a997588f998edf569413250';
 
 /// To-Do 追加画面の ViewModel
 ///


### PR DESCRIPTION
## 概要
Providerを使ってTitleValidatorをViewModelに注入するように修正

## 関連 issue
- close #25 

## 参考
- https://riverpod.dev/ja/docs/concepts/about_code_generation#provider-%E3%81%AE%E5%AE%9A%E7%BE%A9
